### PR TITLE
[Build] Add std::optional include in optional.cc

### DIFF
--- a/coroutines/optional.cc
+++ b/coroutines/optional.cc
@@ -12,6 +12,7 @@
 
 #include <cassert>
 #include <coroutine>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
This patch fixes `optional.cc` build by including `<optional>` in `optional.cc`.